### PR TITLE
add background worker to hit nytimes endpoint every 5 minutes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "tweetstream"
 gem "faraday"
 gem "responders"
 gem "hashie"
+gem "whenever", require: false
 
 group :development, :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       debug_inspector (>= 0.0.1)
     buftok (0.2.0)
     builder (3.2.2)
+    chronic (0.10.2)
     coderay (1.1.0)
     cookiejar (0.3.2)
     crack (0.4.2)
@@ -200,6 +201,8 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -223,3 +226,4 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
+  whenever

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,6 @@
 class Article < ActiveRecord::Base
+  validates :title, uniqueness: true
+
   def self.create_articles(articles_data)
     articles_data.each do |article|
       article = _build_object(article)

--- a/app/services/nytimes_service.rb
+++ b/app/services/nytimes_service.rb
@@ -3,8 +3,8 @@ class NytimesService
 
   def initialize
     @connection ||= Faraday.new(url: "http://api.nytimes.com/svc/topstories/" +
-                                "v1/home.json?" + 
-                                "api-key=b153eb5a98da885cf337dba80557" + 
+                                "v1/home.json?" +
+                                "api-key=b153eb5a98da885cf337dba80557" +
                                 "ac1b:14:71760602")
   end
 

--- a/app/services/nytimes_service.rb
+++ b/app/services/nytimes_service.rb
@@ -3,7 +3,7 @@ class NytimesService
 
   def initialize
     @connection ||= Faraday.new(url: "http://api.nytimes.com/svc/topstories/" +
-                                "v1/home.json?api-key=#{ENV["NYTIMES_KEY"]}")
+                                "v1/home.json?api-key=#{ENV['NYTIMES_KEY']}")
   end
 
   def articles

--- a/app/services/nytimes_service.rb
+++ b/app/services/nytimes_service.rb
@@ -3,9 +3,7 @@ class NytimesService
 
   def initialize
     @connection ||= Faraday.new(url: "http://api.nytimes.com/svc/topstories/" +
-                                "v1/home.json?" +
-                                "api-key=b153eb5a98da885cf337dba80557" +
-                                "ac1b:14:71760602")
+                                "v1/home.json?api-key=#{ENV["NYTIMES_KEY"]}")
   end
 
   def articles

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,4 @@
+every 5.minutes do
+  runner "NytimesService.new.articles"
+  command "echo 'you can use raw cron sytax too'"
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,3 @@
 every 5.minutes do
   runner "NytimesService.new.articles"
-  command "echo 'you can use raw cron sytax too'"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 
 ActiveRecord::Schema.define(version: 20150401224021) do
 
- # These are extensions that must be enabled in order to support this database
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "articles", force: :cascade do |t|
@@ -25,4 +25,5 @@ ActiveRecord::Schema.define(version: 20150401224021) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
 end


### PR DESCRIPTION
Chron Job for fetching Ny Times articles every 5 minutes. We also validated the titles as to only find unique Articles. 

Updated from comments. Thanks!
